### PR TITLE
Unify Tap In form active class and remove duplicate mobile rules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1138,32 +1138,8 @@ img, video {
 
   /* Expanded Form */
   .tap-in-form {
-    display: none;
     width: 80%;
-    margin: 3rem auto;
     padding: 2rem;
-    border-radius: 20px;
-    background: url('images/Apply/ApplicationBoxPattern3.png') center/cover no-repeat;
-    position: relative;
-    transition: all 0.3s ease-in-out;
-  }
-
-  .tap-in-form::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5); /* Subtle dark overlay */
-    border-radius: 20px;
-    z-index: 1;
-  }
-
-  .tap-in-form.slide-in {
-    display: block;
-    opacity: 1;
-    transform: scale(1);
   }
 
   /* Submission Confirmation */
@@ -1190,11 +1166,6 @@ img, video {
     transform: translate(-50%, -50%);
     opacity: 0;
     transition: opacity 0.4s ease-in-out, transform 0.4s ease-in-out;
-  }
-
-  .tap-in-form * {
-    position: relative;
-    z-index: 2;
   }
 
   /* FORM INPUTS (Increased size for better usability) */


### PR DESCRIPTION
### Motivation
- Ensure the Tap In form uses a single state class that matches the existing JS (`.tap-in-form.active`) and remove conflicting `.slide-in` usage across breakpoints.
- Reduce duplicated CSS between desktop and mobile so the base behavior is defined once and mobile only overrides what’s necessary.

### Description
- Consolidated Tap In rules in `styles.css` so the shared base `.tap-in-form` and the visibility state is driven by `.tap-in-form.active` instead of `.tap-in-form.slide-in` in the mobile media query.
- Removed duplicated mobile declarations including the redundant overlay pseudo-element and child positioning so desktop overlay and stacking rules are reused.
- Kept only mobile-specific overrides (like `width`, `padding`, and reduced input sizing) inside the `@media (max-width: 768px)` block.

### Testing
- Loaded the site via a local HTTP server and ran a Playwright script to capture `artifacts/tap-in-form.png`, which completed successfully.
- Verified occurrences with `rg` to confirm `.tap-in-form.active` is present and `.slide-in` form selector was removed, which succeeded.
- No automated CSS unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710b48cd648323975fd354ffc12bbf)