### PR TITLE
Fix collective section heading class

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
   <!-- Member Carousel -->
   <section id="members" class="members-section slide-in">
-    <h2 class="-title">Meet the Collective</h2> <!-- New Title -->
+    <h2 class="section-title">Meet the Collective</h2> <!-- New Title -->
   
     <!-- Category Tabs -->
     <div class="category-tabs">


### PR DESCRIPTION
### Motivation
- Replace the stray `-title` class on the “Meet the Collective” heading with a valid existing class to apply intended styles and avoid a confusing/undefined selector.

### Description
- Update `index.html` to change `<h2 class="-title">Meet the Collective</h2>` to `<h2 class="section-title">Meet the Collective</h2>`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710b4ac2408323a6c15b3a3ee9ec2b)