### PR TITLE
Normalize image src path separators in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
           <h3 class="member-name">Adam Ford</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Adam.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Adam.jpg"
             alt="Adam Ford"
             class="member-image"
           />
@@ -131,10 +131,10 @@
             <!-- <p class="member-bio">Brief artist description here.</p>  -->
             <div class="social-links">
               <a href="https://open.spotify.com/album/6qSLIqTnS9O53UstHTtxYu?si=O5jXW4UzSka43b3bo-k_dg&fbclid=PAZXh0bgNhZW0CMTEAAacSEI5vbSK5gwVwgngZCb4Jcucqfe18Siuoe3jFrWHbYtNw2Ai5f1TcK5yXQw_aem_uhxl3M-7L1M6-s4Ze-jfsg&nd=1&dlsi=7d1a197d57e34b82" class="icon">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/_adam_ford?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -146,7 +146,7 @@
           <h3 class="member-name">Alexandra Holmes</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\AlexH.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/AlexH.jpg"
             alt="Alexandra Holmes"
             class="member-image"
           />
@@ -154,7 +154,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/alexandraseakay?igsh=NGE0a3d3ZmF6Ymlx" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -166,7 +166,7 @@
           <h3 class="member-name">Asta Motrenko</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Asta.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg"
             alt="Asta Motrenko"
             class="member-image"
           />
@@ -174,10 +174,10 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -189,7 +189,7 @@
           <h3 class="member-name">Aman Singh</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Cheez.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Cheez.jpg"
             alt="Aman Singh"
             class="member-image"
           />
@@ -197,13 +197,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/3GJsFHXxjwaBuUP4TmGZUp?si=dgzandHHQ9C3s_ddSHtCBQ&nd=1&dlsi=c0506f8dc2d3456c" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/cheez/1604947918" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/cheezxd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -215,7 +215,7 @@
           <h3 class="member-name">Chris Aviles</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Chris.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Chris.jpg"
             alt="Chris Aviles"
             class="member-image"
           />
@@ -223,16 +223,16 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/4qCMqMDT6g2ozg0ytdxlxG?si=l23dcZjaTsuujxGsudtogQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/avthakidd/1654655936" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://on.soundcloud.com/Zm7X8zPAuSLx3H3YA" class="Soundcloud">
-                <img src="images\Socials\soundcloud-logopng-28186.png" alt="Soundcloud">
+                <img src="images/Socials/soundcloud-logopng-28186.png" alt="Soundcloud">
               </a>
               <a href="https://www.instagram.com/avthakidd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -244,7 +244,7 @@
           <h3 class="member-name">Ezra Passalacqua</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Ezra.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Ezra.jpg"
             alt="Ezra Passalacqua"
             class="member-image"
           />
@@ -252,13 +252,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/5KJGPIr3UeVUMp4DtaXKUl?si=3FtN861yTQC6GapO3QlBHA" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/a-boulder-project/1793637775" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/snap_along?igsh=MXA1OTg5amJxeDVjYw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -270,7 +270,7 @@
           <h3 class="member-name">Francis Andersen</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Francis.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Francis.jpg"
             alt="Francis Andersen"
             class="member-image"
           />
@@ -278,13 +278,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0oKLzlsiZodT1MwchB35kJ?si=Ia6y1rDqTRGnIxjXCIzA-g" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/laine-truly/1780727849" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -296,7 +296,7 @@
           <h3 class="member-name">Geovanny Antunes</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Geo.png"
+            src="images/Profiles/headshots/Geo.png"
             alt="Geovanny Antunes"
             class="member-image"
           />
@@ -304,13 +304,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/3SlHdSVW70W3mB2KWBTIqP?si=4fe883925db54a5a" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/geo-vny/1809501536" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -322,7 +322,7 @@
           <h3 class="member-name">Griffin Hochheiser</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Griffin.png"
+            src="images/Profiles/headshots/Griffin.png"
             alt="Griffin Hochheiser"
             class="member-image"
           />
@@ -330,13 +330,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/louis-laflam/1633639717" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -348,7 +348,7 @@
           <h3 class="member-name">Hooper James</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Hooper.jpg"
+            src="images/Profiles/headshots/Hooper.jpg"
             alt="Hooper James"
             class="member-image"
           />
@@ -356,13 +356,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/hooper-james/1613266433" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -374,7 +374,7 @@
           <h3 class="member-name">João Victor Borges Fontaim</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\VIC.jpeg"
+            src="images/Profiles/headshots/VIC.jpeg"
             alt="João Victor Borges Fontaim"
             class="member-image"
           />
@@ -382,13 +382,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/1FrP7NzvMuTcA3cE1oicio?si=368_ZV0YTlWNKnIBzwrVvQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/vais/1803895050" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/vais.xv?igsh=MTBhNmo4aHZrZnBlYQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -400,7 +400,7 @@
           <h3 class="member-name">Joaquin Cuevas-Torres</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\JOAQUIN.png"
+            src="images/Profiles/headshots/JOAQUIN.png"
             alt="Joaquin Cuevas-Torres"
             class="member-image"
           />
@@ -408,7 +408,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/joaqo_bajo?igsh=bmtjNThkMTNrdzlo" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -420,7 +420,7 @@
           <h3 class="member-name">Jacob Torres</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Jacob.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Jacob.jpg"
             alt="Jacob Torres"
             class="member-image"
           />
@@ -428,10 +428,10 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/6Uke5khIxBDhlymR78w5n0?si=57bac1cfad9c4f24" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/jtorres.204?igsh=Y2t0ajQ3NGZzazFs" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -443,7 +443,7 @@
           <h3 class="member-name">Joshua Jackson</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Josh.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Josh.jpg"
             alt="Joshua Jackson"
             class="member-image"
           />
@@ -451,13 +451,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/7BpPoCg1upBCRsepdo6R6V?si=yyViBNmiS9SO7S3cq-XwVg" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/jarou/1536806066" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/joshuajackson.04?igsh=NmZjdHIzN29kZnZo" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -469,7 +469,7 @@
           <h3 class="member-name">Juliana Marquez</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Juliana.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg"
             alt="Juliana Marquez"
             class="member-image"
           />
@@ -477,7 +477,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -489,7 +489,7 @@
           <h3 class="member-name">Justin Vaughn</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Justin.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Justin.jpg"
             alt="Justin Vaughn"
             class="member-image"
           />
@@ -497,7 +497,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/jvonnn_2?igsh=MWxvM2JqaGZhOG9ieQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -509,7 +509,7 @@
           <h3 class="member-name">Liam Ingraham</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Liam.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Liam.jpg"
             alt="Liam Ingraham"
             class="member-image"
           />
@@ -517,13 +517,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/07r2YH0PPyQNfzRqKADYsS?si=sYdwTtm-S5a_xfGzLqGGYQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/liam-ingraham/1620737658" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/liamingraham?igsh=MXhseTlxaHpjeHN1eg==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -535,7 +535,7 @@
           <h3 class="member-name">Matthew Ciampa</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Matty.jpg"
+            src="images/Profiles/headshots/Matty.jpg"
             alt="Nevaeh Duah"
             class="member-image"
           />
@@ -543,7 +543,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -555,7 +555,7 @@
           <h3 class="member-name">Nevaeh Duah</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Nevaeh.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Nevaeh.jpg"
             alt="Nevaeh Duah"
             class="member-image"
           />
@@ -563,7 +563,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -575,7 +575,7 @@
           <h3 class="member-name">Nick Cobosco</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Nick.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Nick.jpg"
             alt="Nick Cobosco"
             class="member-image"
           />
@@ -583,7 +583,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/nick.cobosco?igsh=MWF0amw3c2d0Ynh5cw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -595,7 +595,7 @@
           <h3 class="member-name">Vrishabh Shriwardhankar</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Vrish.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Vrish.jpg"
             alt="Vrishabh Shriwardhankar"
             class="member-image"
           />
@@ -603,13 +603,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0xoYV7eUNlToK31Se7wCrx?si=MhS7NjkPQ9uLEi4uzMQyvg" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/vir-sind/1794861294" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/vrishabhmusic?igsh=MXZqMnNvbnk1ZnBkbA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -621,7 +621,7 @@
           <h3 class="member-name">Zoe Mazzaferro</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Zoe.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Zoe.jpg"
             alt="Zoe Mazzaferro"
             class="member-image"
           />
@@ -629,13 +629,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0C8xX78ztv4YfyIq1VvtV1?si=pWHfOwyZRUCBVqOR4EefXw" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/voidgirl/1742911243" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/voidgirl.x3?igsh=eWduMmppZTZ3ZjB4" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -650,7 +650,7 @@
           <h3 class="member-name">Vrishabh Shriwardhankar</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\VirSind.png"
+            src="images/Profiles/headshots/VirSind.png"
             alt="Vrishabh Shriwardhankar"
             class="member-image"
           />
@@ -658,13 +658,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0xoYV7eUNlToK31Se7wCrx?si=MhS7NjkPQ9uLEi4uzMQyvg" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/vir-sind/1794861294" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/vrishabhmusic?igsh=MXZqMnNvbnk1ZnBkbA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -676,7 +676,7 @@
           <h3 class="member-name">Hooper James</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Hooper.jpg"
+            src="images/Profiles/headshots/Hooper.jpg"
             alt="Hooper James"
             class="member-image"
           />
@@ -684,13 +684,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/hooper-james/1613266433" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -702,7 +702,7 @@
           <h3 class="member-name">Juliana Marquez</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Juliana.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg"
             alt="Juliana Marquez"
             class="member-image"
           />
@@ -710,7 +710,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -722,7 +722,7 @@
           <h3 class="member-name">Geovanny Antunes</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Geo.png"
+            src="images/Profiles/headshots/Geo.png"
             alt="Geovanny Antunes"
             class="member-image"
           />
@@ -730,13 +730,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/3SlHdSVW70W3mB2KWBTIqP?si=4fe883925db54a5a" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/geo-vny/1809501536" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -748,7 +748,7 @@
           <h3 class="member-name">Nevaeh Duah</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Nevaeh.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Nevaeh.jpg"
             alt="Nevaeh Duah"
             class="member-image"
           />
@@ -756,7 +756,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -768,7 +768,7 @@
           <h3 class="member-name">Joshua Jackson</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Josh.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Josh.jpg"
             alt="Joshua Jackson"
             class="member-image"
           />
@@ -776,13 +776,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/7BpPoCg1upBCRsepdo6R6V?si=yyViBNmiS9SO7S3cq-XwVg" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/jarou/1536806066" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/joshuajackson.04?igsh=NmZjdHIzN29kZnZo" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -794,7 +794,7 @@
           <h3 class="member-name">Francis Andersen</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Francis.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Francis.jpg"
             alt="Francis Andersen"
             class="member-image"
           />
@@ -802,13 +802,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0oKLzlsiZodT1MwchB35kJ?si=Ia6y1rDqTRGnIxjXCIzA-g" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/laine-truly/1780727849" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -820,7 +820,7 @@
           <h3 class="member-name">Liam Ingraham</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Liam.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Liam.jpg"
             alt="Liam Ingraham"
             class="member-image"
           />
@@ -828,13 +828,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/07r2YH0PPyQNfzRqKADYsS?si=sYdwTtm-S5a_xfGzLqGGYQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/liam-ingraham/1620737658" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/liamingraham?igsh=MXhseTlxaHpjeHN1eg==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -846,7 +846,7 @@
           <h3 class="member-name">Asta Motrenko</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Asta.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg"
             alt="Asta Motrenko"
             class="member-image"
           />
@@ -854,10 +854,10 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -869,7 +869,7 @@
           <h3 class="member-name">Aman Singh</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Cheez.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Cheez.jpg"
             alt="Aman Singh"
             class="member-image"
           />
@@ -877,13 +877,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/3GJsFHXxjwaBuUP4TmGZUp?si=dgzandHHQ9C3s_ddSHtCBQ&nd=1&dlsi=c0506f8dc2d3456c" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/cheez/1604947918" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/cheezxd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -897,7 +897,7 @@
           <h3 class="member-name">Griffin Hochheiser</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Griffin.png"
+            src="images/Profiles/headshots/Griffin.png"
             alt="Griffin Hochheiser"
             class="member-image"
           />
@@ -905,13 +905,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/louis-laflam/1633639717" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -923,7 +923,7 @@
           <h3 class="member-name">Zoe Mazzaferro</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Zoe.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Zoe.jpg"
             alt="Zoe Mazzaferro"
             class="member-image"
           />
@@ -931,13 +931,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0C8xX78ztv4YfyIq1VvtV1?si=pWHfOwyZRUCBVqOR4EefXw" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/voidgirl/1742911243" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/voidgirl.x3?igsh=eWduMmppZTZ3ZjB4" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -949,7 +949,7 @@
           <h3 class="member-name">Ezra Passalacqua</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Ezra.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Ezra.jpg"
             alt="Ezra Passalacqua"
             class="member-image"
           />
@@ -957,13 +957,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/5KJGPIr3UeVUMp4DtaXKUl?si=3FtN861yTQC6GapO3QlBHA" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/a-boulder-project/1793637775" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/snap_along?igsh=MXA1OTg5amJxeDVjYw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -975,7 +975,7 @@
           <h3 class="member-name">Justin Vaughn</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Justin.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Justin.jpg"
             alt="Justin Vaughn"
             class="member-image"
           />
@@ -983,7 +983,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/jvonnn_2?igsh=MWxvM2JqaGZhOG9ieQ==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -997,7 +997,7 @@
           <h3 class="member-name">Alexanda Holmes</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\AlexH.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/AlexH.jpg"
             alt="Alexandra Holmes"
             class="member-image"
           />
@@ -1005,7 +1005,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/alexandraseakay?igsh=NGE0a3d3ZmF6Ymlx" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1017,7 +1017,7 @@
           <h3 class="member-name">Chris Aviles</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Chris.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Chris.jpg"
             alt="Chris Aviles"
             class="member-image"
           />
@@ -1025,16 +1025,16 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/4qCMqMDT6g2ozg0ytdxlxG?si=l23dcZjaTsuujxGsudtogQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/avthakidd/1654655936" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://on.soundcloud.com/Zm7X8zPAuSLx3H3YA" class="Soundcloud">
-                <img src="images\Socials\soundcloud-logopng-28186.png" alt="Soundcloud">
+                <img src="images/Socials/soundcloud-logopng-28186.png" alt="Soundcloud">
               </a>
               <a href="https://www.instagram.com/avthakidd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1046,7 +1046,7 @@
           <h3 class="member-name">Nick Cobosco</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Nick.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Nick.jpg"
             alt="Nick Cobosco"
             class="member-image"
           />
@@ -1054,7 +1054,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/nick.cobosco?igsh=MWF0amw3c2d0Ynh5cw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1066,7 +1066,7 @@
           <h3 class="member-name">Juliana Marquez</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Juliana.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg"
             alt="Juliana Marquez"
             class="member-image"
           />
@@ -1074,7 +1074,7 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1086,7 +1086,7 @@
           <h3 class="member-name">Asta Motrenko</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Asta.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg"
             alt="Asta Motrenko"
             class="member-image"
           />
@@ -1094,10 +1094,10 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1109,7 +1109,7 @@
           <h3 class="member-name">Hooper James</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Hooper.jpg"
+            src="images/Profiles/headshots/Hooper.jpg"
             alt="Hooper James"
             class="member-image"
           />
@@ -1117,13 +1117,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/hooper-james/1613266433" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1135,7 +1135,7 @@
           <h3 class="member-name">Jacob Torres</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\drive-download-20250428T040202Z-001\Jacob.jpg"
+            src="images/Profiles/headshots/drive-download-20250428T040202Z-001/Jacob.jpg"
             alt="Jacob Torres"
             class="member-image"
           />
@@ -1143,10 +1143,10 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/track/6Uke5khIxBDhlymR78w5n0?si=57bac1cfad9c4f24" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://www.instagram.com/jtorres.204?igsh=Y2t0ajQ3NGZzazFs" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1158,7 +1158,7 @@
           <h3 class="member-name">Griffin Hochheiser</h3>
           <!-- Photo -->
           <img
-            src="images\Profiles\headshots\Griffin.png"
+            src="images/Profiles/headshots/Griffin.png"
             alt="Griffin Hochheiser"
             class="member-image"
           />
@@ -1166,13 +1166,13 @@
           <div class="member-details">
             <div class="social-links">
               <a href="https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ" class="spotify">
-                <img src="images\Socials\Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
+                <img src="images/Socials/Spotify_Primary_Logo_RGB_Green.png" alt="Spotify">
               </a>
               <a href="https://music.apple.com/us/artist/louis-laflam/1633639717" class="apple-music">
-                <img src="images\Socials\Apple-Music-Logo-PNG.png" alt="Apple Music">
+                <img src="images/Socials/Apple-Music-Logo-PNG.png" alt="Apple Music">
               </a>
               <a href="https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs" class="instagram">
-                <img src="images\Socials\Instagram.png" alt="Instagram">
+                <img src="images/Socials/Instagram.png" alt="Instagram">
               </a>
             </div>
           </div>
@@ -1219,10 +1219,10 @@
     <h2 class="social-title">SEE US</h2>
     <div class="social-links">
       <a href="https://www.instagram.com/vvisioncollective/" class="social-icons">
-        <img src="images\Socials\Instagram.png" alt="Instagram">
+        <img src="images/Socials/Instagram.png" alt="Instagram">
       </a>
       <a href="https://www.tiktok.com/@vivid.vision.inc?is_from_webapp=1&sender_device=pc " class="social-icons">
-        <img src="images\Socials\tik-tok-logo-transparent-031f.png" alt="tiktok">
+        <img src="images/Socials/tik-tok-logo-transparent-031f.png" alt="tiktok">
       </a>
     </div>
   </section>


### PR DESCRIPTION
### Motivation
- Ensure image paths use web-standard forward slashes so images load consistently across platforms and servers.
- Normalize path separators for consistency without changing folder layout or filenames.

### Description
- Replaced backslashes (`\`) with forward slashes (`/`) in all image `src` attribute values in `index.html` while preserving the existing folder structure and filenames. 
- Updated profile headshots, social icon images, and repeated member entries across the Members/Artists/Producers/Legislative sections. 
- Left non-`src` occurrences (for example the favicon `href`) untouched and committed the change with message `Normalize image src paths`.

### Testing
- Searched the file with `rg -F "src=\"images\\" index.html` to identify occurrences before the change, which returned many matches. — succeeded.
- Ran a Python script to replace backslashes in `src` attribute values and wrote the updated `index.html`. — succeeded.
- Re-ran `rg -n -F "\\" index.html` and `rg -n -F "src=\"images\\" index.html` to verify `src="images\` occurrences were removed (only a favicon `href` with backslashes remains and was intentionally not changed). — verification succeeded.
- Committed the updated `index.html`. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710b4d5fb48323805130a2daab483b)