### PR TITLE
Migrate site to static Astro app with components, team data, scripts and tooling

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-astro"]
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Vivid Vision Website Refactor (Static Astro)
+
+## Target stack
+This refactor uses **Astro + Vite** to keep the site static-hostable while introducing reusable components and content-driven data files.
+
+## Refactor plan
+1. Audit legacy `index.html` / `styles.css` / `main.js` and preserve behavior exactly.
+2. Migrate into structured `src/` layout (pages/components/scripts/styles/content).
+3. Externalize team entries into a single JSON file used by the carousel component.
+4. Add lightweight tooling (dev/build scripts, ESLint, Prettier).
+5. Keep static deployment compatibility (`dist/`).
+
+## Final file tree
+```text
+.
+├── astro.config.mjs
+├── package.json
+├── eslint.config.mjs
+├── .prettierrc
+├── src/
+│   ├── components/
+│   │   ├── Footer.astro
+│   │   ├── Header.astro
+│   │   ├── Hero.astro
+│   │   ├── JoinForm.astro
+│   │   ├── Mission.astro
+│   │   ├── Socials.astro
+│   │   └── TeamCarousel.astro
+│   ├── content/
+│   │   └── team.json
+│   ├── layouts/
+│   │   └── BaseLayout.astro
+│   ├── pages/
+│   │   └── index.astro
+│   ├── scripts/
+│   │   ├── carousel.js
+│   │   ├── form.js
+│   │   ├── hero.js
+│   │   ├── main.js
+│   │   ├── nav.js
+│   │   └── scroll.js
+│   └── styles/
+│       └── global.css
+└── images/ (existing assets used as Astro publicDir)
+```
+
+## Run locally
+```bash
+npm install
+npm run dev
+npm run build
+npm run preview
+```
+
+## Deployment
+- Build with `npm run build`
+- Deploy static output from `dist/`
+- Compatible with Netlify, Vercel static, GitHub Pages, and other static hosts.
+- Preserve existing DNS/domain configuration for `vividvisioncollective.com`.
+
+## What changed internally
+- Monolithic page markup split into reusable Astro components.
+- Team cards moved to `src/content/team.json` for easy non-engineer edits.
+- Legacy JS split into focused modules without changing behavior.
+- Legacy styling moved to `src/styles/global.css` with path adjustments only for static asset resolution.
+
+## What remained intentionally identical
+- Information architecture and copy (Home / Mission / Team / Join / Socials).
+- Carousel categories, arrows, and card interactions.
+- Tap-in form + confirmation flow and Formspree endpoint.
+- Existing look-and-feel, spacing, colors, and animation timing.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  output: 'static',
+  publicDir: './images'
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,14 @@
+import eslintPluginAstro from 'eslint-plugin-astro';
+import globals from 'globals';
+
+export default [
+  ...eslintPluginAstro.configs.recommended,
+  {
+    files: ['**/*.{js,mjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: globals.browser
+    }
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vvweb",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "astro": "^5.5.5",
+    "eslint": "^9.21.0",
+    "eslint-plugin-astro": "^0.34.0",
+    "globals": "^15.15.0",
+    "prettier": "^3.5.2",
+    "prettier-plugin-astro": "^0.14.1"
+  }
+}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,3 @@
+<footer class="site-footer">
+  <p>© 2025 Vivid Vision Incorporated. A 501(c)(3) entity. All Rights Reserved.</p>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,12 @@
+<header class="site-header">
+  <img src="/VV-icon whitegold.png" alt="Logo" class="logo-img" />
+  <nav class="main-nav">
+    <ul>
+      <li><a href="#" class="active">Home</a></li>
+      <li><a href="#mission-statement">Mission</a></li>
+      <li><a href="#members">Team</a></li>
+      <li><a href="#tap-in">Join</a></li>
+      <li><a href="#socials">Socials</a></li>
+    </ul>
+  </nav>
+</header>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,22 @@
+<section class="hero">
+  <img src="/VV-text.png" alt="Logo" class="parallax-image" />
+  <div class="hero-overlay">
+    <p class="intro-text">A collective of:</p>
+    <p class="key-roles">
+      <span class="dynamic-words">
+        <span>Members</span>
+        <span>Artists</span>
+        <span>Producers</span>
+        <span>Musicians</span>
+        <span>Designers</span>
+        <span>Legislators</span>
+        <span>Visionaries</span>
+        <span>Hobbyists</span>
+        <span>DOPE HUMANS</span>
+        <span>CREATIVES</span>
+      </span>
+    </p>
+    <p class="hero-statement">working to facilitate real art, <span class="emphasis">nothing less.</span></p>
+    <p class="tagline">This is the <span class="glow">vision</span>.</p>
+  </div>
+</section>

--- a/src/components/JoinForm.astro
+++ b/src/components/JoinForm.astro
@@ -1,0 +1,17 @@
+<section id="tap-in" class="tap-in-section slide-in">
+  <button id="tapInButton" class="tap-in-btn">Tap In</button>
+  <div id="tapInForm" class="tap-in-form">
+    <form id="applicationForm">
+      <label for="email">Your Email:</label>
+      <input type="email" id="email" name="email" required />
+      <label for="message">Tell Us About Yourself:</label>
+      <textarea id="message" name="message" rows="4" required></textarea>
+      <label for="message">(Dropbox and Drive links accepted)</label>
+      <button type="submit" class="apply-btn">Apply</button>
+    </form>
+  </div>
+  <div id="confirmationMessage" class="confirmation-message">
+    <h2>Application Submitted</h2>
+    <p>We’ll be reaching out soon...</p>
+  </div>
+</section>

--- a/src/components/Mission.astro
+++ b/src/components/Mission.astro
@@ -1,0 +1,14 @@
+<section id="mission-statement" class="mission-statement slide-in">
+  <h2 class="section-title">Our Mission</h2>
+  <div class="mission-cards">
+    <div class="mission-card" data-title="Quality">
+      <p class="mission-text">We create with intention, not trends.</p>
+    </div>
+    <div class="mission-card" data-title="Community">
+      <p class="mission-text">We build spaces where art empowers, connects, and mobilizes.</p>
+    </div>
+    <div class="mission-card" data-title="Independence">
+      <p class="mission-text">Artists retain full control and fair ownership. <br />We grow without compromise.</p>
+    </div>
+  </div>
+</section>

--- a/src/components/Socials.astro
+++ b/src/components/Socials.astro
@@ -1,0 +1,11 @@
+<section id="socials" class="socials-section slide-in">
+  <h2 class="social-title">SEE US</h2>
+  <div class="social-links">
+    <a href="https://www.instagram.com/vvisioncollective/" class="social-icons">
+      <img src="/Socials/Instagram.png" alt="Instagram" />
+    </a>
+    <a href="https://www.tiktok.com/@vivid.vision.inc?is_from_webapp=1&sender_device=pc " class="social-icons">
+      <img src="/Socials/tik-tok-logo-transparent-031f.png" alt="tiktok" />
+    </a>
+  </div>
+</section>

--- a/src/components/TeamCarousel.astro
+++ b/src/components/TeamCarousel.astro
@@ -1,0 +1,46 @@
+---
+import team from '../content/team.json';
+
+const tabs = [
+  { key: 'members', label: 'Members' },
+  { key: 'Artists', label: 'Artists' },
+  { key: 'Producers', label: 'Producers' },
+  { key: 'Legislative', label: 'Legislative' }
+];
+---
+
+<section id="members" class="members-section slide-in">
+  <h2 class="section-title">Meet the Collective</h2>
+  <div class="category-tabs">
+    {
+      tabs.map((tab, index) => (
+        <span class={`tab ${index === 0 ? 'active' : ''}`} data-category={tab.key}>{tab.label}</span>
+      ))
+    }
+  </div>
+  <div class="carousel">
+    <button class="arrow left-arrow">&lt;</button>
+    <div class="carousel-inner">
+      {
+        team.map((member) => (
+          <div class="member-card" data-category={member.category}>
+            <h3 class="member-name">{member.name}</h3>
+            <img src={member.image} alt={member.imageAlt} class="member-image" />
+            <div class="member-details">
+              <div class="social-links">
+                {
+                  member.links.map((link) => (
+                    <a href={link.href} class={link.className}>
+                      <img src={link.icon} alt={link.alt} />
+                    </a>
+                  ))
+                }
+              </div>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+    <button class="arrow right-arrow">&gt;</button>
+  </div>
+</section>

--- a/src/content/team.json
+++ b/src/content/team.json
@@ -1,0 +1,966 @@
+[
+  {
+    "category": "members",
+    "name": "Adam Ford",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Adam.jpg",
+    "imageAlt": "Adam Ford",
+    "links": [
+      {
+        "href": "https://open.spotify.com/album/6qSLIqTnS9O53UstHTtxYu?si=O5jXW4UzSka43b3bo-k_dg&fbclid=PAZXh0bgNhZW0CMTEAAacSEI5vbSK5gwVwgngZCb4Jcucqfe18Siuoe3jFrWHbYtNw2Ai5f1TcK5yXQw_aem_uhxl3M-7L1M6-s4Ze-jfsg&nd=1&dlsi=7d1a197d57e34b82",
+        "className": "icon",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/_adam_ford?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Alexandra Holmes",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/AlexH.jpg",
+    "imageAlt": "Alexandra Holmes",
+    "links": [
+      {
+        "href": "https://www.instagram.com/alexandraseakay?igsh=NGE0a3d3ZmF6Ymlx",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Asta Motrenko",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg",
+    "imageAlt": "Asta Motrenko",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Aman Singh",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Cheez.jpg",
+    "imageAlt": "Aman Singh",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/3GJsFHXxjwaBuUP4TmGZUp?si=dgzandHHQ9C3s_ddSHtCBQ&nd=1&dlsi=c0506f8dc2d3456c",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/cheez/1604947918",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/cheezxd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Chris Aviles",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Chris.jpg",
+    "imageAlt": "Chris Aviles",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/4qCMqMDT6g2ozg0ytdxlxG?si=l23dcZjaTsuujxGsudtogQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/avthakidd/1654655936",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://on.soundcloud.com/Zm7X8zPAuSLx3H3YA",
+        "className": "Soundcloud",
+        "icon": "/Socials/soundcloud-logopng-28186.png",
+        "alt": "Soundcloud"
+      },
+      {
+        "href": "https://www.instagram.com/avthakidd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Ezra Passalacqua",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Ezra.jpg",
+    "imageAlt": "Ezra Passalacqua",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/5KJGPIr3UeVUMp4DtaXKUl?si=3FtN861yTQC6GapO3QlBHA",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/a-boulder-project/1793637775",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/snap_along?igsh=MXA1OTg5amJxeDVjYw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Francis Andersen",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Francis.jpg",
+    "imageAlt": "Francis Andersen",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0oKLzlsiZodT1MwchB35kJ?si=Ia6y1rDqTRGnIxjXCIzA-g",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/laine-truly/1780727849",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Geovanny Antunes",
+    "image": "/Profiles/headshots/Geo.png",
+    "imageAlt": "Geovanny Antunes",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/3SlHdSVW70W3mB2KWBTIqP?si=4fe883925db54a5a",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/geo-vny/1809501536",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Griffin Hochheiser",
+    "image": "/Profiles/headshots/Griffin.png",
+    "imageAlt": "Griffin Hochheiser",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/louis-laflam/1633639717",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Hooper James",
+    "image": "/Profiles/headshots/Hooper.jpg",
+    "imageAlt": "Hooper James",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/hooper-james/1613266433",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Jo\u00e3o Victor Borges Fontaim",
+    "image": "/Profiles/headshots/VIC.jpeg",
+    "imageAlt": "Jo\u00e3o Victor Borges Fontaim",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/1FrP7NzvMuTcA3cE1oicio?si=368_ZV0YTlWNKnIBzwrVvQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/vais/1803895050",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/vais.xv?igsh=MTBhNmo4aHZrZnBlYQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Joaquin Cuevas-Torres",
+    "image": "/Profiles/headshots/JOAQUIN.png",
+    "imageAlt": "Joaquin Cuevas-Torres",
+    "links": [
+      {
+        "href": "https://www.instagram.com/joaqo_bajo?igsh=bmtjNThkMTNrdzlo",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Jacob Torres",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Jacob.jpg",
+    "imageAlt": "Jacob Torres",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/6Uke5khIxBDhlymR78w5n0?si=57bac1cfad9c4f24",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/jtorres.204?igsh=Y2t0ajQ3NGZzazFs",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Joshua Jackson",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Josh.jpg",
+    "imageAlt": "Joshua Jackson",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/7BpPoCg1upBCRsepdo6R6V?si=yyViBNmiS9SO7S3cq-XwVg",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/jarou/1536806066",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/joshuajackson.04?igsh=NmZjdHIzN29kZnZo",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Juliana Marquez",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg",
+    "imageAlt": "Juliana Marquez",
+    "links": [
+      {
+        "href": "https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Justin Vaughn",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Justin.jpg",
+    "imageAlt": "Justin Vaughn",
+    "links": [
+      {
+        "href": "https://www.instagram.com/jvonnn_2?igsh=MWxvM2JqaGZhOG9ieQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Liam Ingraham",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Liam.jpg",
+    "imageAlt": "Liam Ingraham",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/07r2YH0PPyQNfzRqKADYsS?si=sYdwTtm-S5a_xfGzLqGGYQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/liam-ingraham/1620737658",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/liamingraham?igsh=MXhseTlxaHpjeHN1eg==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Matthew Ciampa",
+    "image": "/Profiles/headshots/Matty.jpg",
+    "imageAlt": "Nevaeh Duah",
+    "links": [
+      {
+        "href": "https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Nevaeh Duah",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Nevaeh.jpg",
+    "imageAlt": "Nevaeh Duah",
+    "links": [
+      {
+        "href": "https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Nick Cobosco",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Nick.jpg",
+    "imageAlt": "Nick Cobosco",
+    "links": [
+      {
+        "href": "https://www.instagram.com/nick.cobosco?igsh=MWF0amw3c2d0Ynh5cw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Vrishabh Shriwardhankar",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Vrish.jpg",
+    "imageAlt": "Vrishabh Shriwardhankar",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0xoYV7eUNlToK31Se7wCrx?si=MhS7NjkPQ9uLEi4uzMQyvg",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/vir-sind/1794861294",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/vrishabhmusic?igsh=MXZqMnNvbnk1ZnBkbA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "members",
+    "name": "Zoe Mazzaferro",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Zoe.jpg",
+    "imageAlt": "Zoe Mazzaferro",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0C8xX78ztv4YfyIq1VvtV1?si=pWHfOwyZRUCBVqOR4EefXw",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/voidgirl/1742911243",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/voidgirl.x3?igsh=eWduMmppZTZ3ZjB4",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Vrishabh Shriwardhankar",
+    "image": "/Profiles/headshots/VirSind.png",
+    "imageAlt": "Vrishabh Shriwardhankar",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0xoYV7eUNlToK31Se7wCrx?si=MhS7NjkPQ9uLEi4uzMQyvg",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/vir-sind/1794861294",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/vrishabhmusic?igsh=MXZqMnNvbnk1ZnBkbA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Hooper James",
+    "image": "/Profiles/headshots/Hooper.jpg",
+    "imageAlt": "Hooper James",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/hooper-james/1613266433",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Juliana Marquez",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg",
+    "imageAlt": "Juliana Marquez",
+    "links": [
+      {
+        "href": "https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Geovanny Antunes",
+    "image": "/Profiles/headshots/Geo.png",
+    "imageAlt": "Geovanny Antunes",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/3SlHdSVW70W3mB2KWBTIqP?si=4fe883925db54a5a",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/geo-vny/1809501536",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Nevaeh Duah",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Nevaeh.jpg",
+    "imageAlt": "Nevaeh Duah",
+    "links": [
+      {
+        "href": "https://www.instagram.com/theamazingnevaeh?igsh=MTd3bGw3YmM0bzU0dQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Joshua Jackson",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Josh.jpg",
+    "imageAlt": "Joshua Jackson",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/7BpPoCg1upBCRsepdo6R6V?si=yyViBNmiS9SO7S3cq-XwVg",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/jarou/1536806066",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/joshuajackson.04?igsh=NmZjdHIzN29kZnZo",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Francis Andersen",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Francis.jpg",
+    "imageAlt": "Francis Andersen",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0oKLzlsiZodT1MwchB35kJ?si=Ia6y1rDqTRGnIxjXCIzA-g",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/laine-truly/1780727849",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/laine_truly2?igsh=MWk1bDhqYWQwdmtpaA==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Liam Ingraham",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Liam.jpg",
+    "imageAlt": "Liam Ingraham",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/07r2YH0PPyQNfzRqKADYsS?si=sYdwTtm-S5a_xfGzLqGGYQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/liam-ingraham/1620737658",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/liamingraham?igsh=MXhseTlxaHpjeHN1eg==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Asta Motrenko",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg",
+    "imageAlt": "Asta Motrenko",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Artists",
+    "name": "Aman Singh",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Cheez.jpg",
+    "imageAlt": "Aman Singh",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/3GJsFHXxjwaBuUP4TmGZUp?si=dgzandHHQ9C3s_ddSHtCBQ&nd=1&dlsi=c0506f8dc2d3456c",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/cheez/1604947918",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/cheezxd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Producers",
+    "name": "Griffin Hochheiser",
+    "image": "/Profiles/headshots/Griffin.png",
+    "imageAlt": "Griffin Hochheiser",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/louis-laflam/1633639717",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Producers",
+    "name": "Zoe Mazzaferro",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Zoe.jpg",
+    "imageAlt": "Zoe Mazzaferro",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0C8xX78ztv4YfyIq1VvtV1?si=pWHfOwyZRUCBVqOR4EefXw",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/voidgirl/1742911243",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/voidgirl.x3?igsh=eWduMmppZTZ3ZjB4",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Producers",
+    "name": "Ezra Passalacqua",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Ezra.jpg",
+    "imageAlt": "Ezra Passalacqua",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/5KJGPIr3UeVUMp4DtaXKUl?si=3FtN861yTQC6GapO3QlBHA",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/a-boulder-project/1793637775",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/snap_along?igsh=MXA1OTg5amJxeDVjYw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Producers",
+    "name": "Justin Vaughn",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Justin.jpg",
+    "imageAlt": "Justin Vaughn",
+    "links": [
+      {
+        "href": "https://www.instagram.com/jvonnn_2?igsh=MWxvM2JqaGZhOG9ieQ==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Alexanda Holmes",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/AlexH.jpg",
+    "imageAlt": "Alexandra Holmes",
+    "links": [
+      {
+        "href": "https://www.instagram.com/alexandraseakay?igsh=NGE0a3d3ZmF6Ymlx",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Chris Aviles",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Chris.jpg",
+    "imageAlt": "Chris Aviles",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/4qCMqMDT6g2ozg0ytdxlxG?si=l23dcZjaTsuujxGsudtogQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/avthakidd/1654655936",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://on.soundcloud.com/Zm7X8zPAuSLx3H3YA",
+        "className": "Soundcloud",
+        "icon": "/Socials/soundcloud-logopng-28186.png",
+        "alt": "Soundcloud"
+      },
+      {
+        "href": "https://www.instagram.com/avthakidd?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Nick Cobosco",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Nick.jpg",
+    "imageAlt": "Nick Cobosco",
+    "links": [
+      {
+        "href": "https://www.instagram.com/nick.cobosco?igsh=MWF0amw3c2d0Ynh5cw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Juliana Marquez",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Juliana.jpg",
+    "imageAlt": "Juliana Marquez",
+    "links": [
+      {
+        "href": "https://www.instagram.com/julianamaro23?igsh=NG1udm1ybmt1am5z",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Asta Motrenko",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Asta.jpg",
+    "imageAlt": "Asta Motrenko",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/4a5VmhdVY3QQJmER83dnQD?si=6KGmIAyGQZSobxLpV3OdIw&fbclid=PAZXh0bgNhZW0CMTEAAaeKr9YtPgM79CTQtqwSEtpnPF1fQ6VITMm_XWsB6PQyvqYEIq24_mjnYJJXVw_aem_dzl0e8DVHka0rsPZnvdGfQ&nd=1&dlsi=2bea499ce2424073",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/_astkka_?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Hooper James",
+    "image": "/Profiles/headshots/Hooper.jpg",
+    "imageAlt": "Hooper James",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/2fIXwhTTPOyJumWgfUe5Mu?si=FBEUJ4dTR2GnzDx-9_TfFA",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/hooper-james/1613266433",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/hooperjamesofficial?igsh=MW1ieGdoMmd0OWMyMw==",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Jacob Torres",
+    "image": "/Profiles/headshots/drive-download-20250428T040202Z-001/Jacob.jpg",
+    "imageAlt": "Jacob Torres",
+    "links": [
+      {
+        "href": "https://open.spotify.com/track/6Uke5khIxBDhlymR78w5n0?si=57bac1cfad9c4f24",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://www.instagram.com/jtorres.204?igsh=Y2t0ajQ3NGZzazFs",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  },
+  {
+    "category": "Legislative",
+    "name": "Griffin Hochheiser",
+    "image": "/Profiles/headshots/Griffin.png",
+    "imageAlt": "Griffin Hochheiser",
+    "links": [
+      {
+        "href": "https://open.spotify.com/artist/0csrnac6Brz8oXKgkwFGRv?si=RTWu7_ksRHSKewklDJAxJQ",
+        "className": "spotify",
+        "icon": "/Socials/Spotify_Primary_Logo_RGB_Green.png",
+        "alt": "Spotify"
+      },
+      {
+        "href": "https://music.apple.com/us/artist/louis-laflam/1633639717",
+        "className": "apple-music",
+        "icon": "/Socials/Apple-Music-Logo-PNG.png",
+        "alt": "Apple Music"
+      },
+      {
+        "href": "https://www.instagram.com/griffinlouislaflam?igsh=a2NlM3R0aWtocDJs",
+        "className": "instagram",
+        "icon": "/Socials/Instagram.png",
+        "alt": "Instagram"
+      }
+    ]
+  }
+]

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,25 @@
+---
+import '../styles/global.css';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="icon" type="image/png" href="/VV-icon blackgold.png" />
+    <meta charset="UTF-8" />
+    <title>The Vivid Vision</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&family=Poppins:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <slot />
+    <script type="module">import '../scripts/main.js';</script>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,20 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Footer from '../components/Footer.astro';
+import Header from '../components/Header.astro';
+import Hero from '../components/Hero.astro';
+import JoinForm from '../components/JoinForm.astro';
+import Mission from '../components/Mission.astro';
+import Socials from '../components/Socials.astro';
+import TeamCarousel from '../components/TeamCarousel.astro';
+---
+
+<BaseLayout>
+  <Header />
+  <Hero />
+  <Mission />
+  <TeamCarousel />
+  <JoinForm />
+  <Socials />
+  <Footer />
+</BaseLayout>

--- a/src/scripts/carousel.js
+++ b/src/scripts/carousel.js
@@ -1,0 +1,74 @@
+export function initTeamCarousel() {
+  const tabs = document.querySelectorAll('.tab');
+  const memberCards = document.querySelectorAll('.member-card');
+  const leftArrow = document.querySelector('.left-arrow');
+  const rightArrow = document.querySelector('.right-arrow');
+  if (!tabs.length || !memberCards.length || !leftArrow || !rightArrow) return;
+
+  let activeCategory = 'artists';
+  let activeIndex;
+  let prevIndex;
+  let nextIndex;
+
+  function switchCategory(category) {
+    activeCategory = category;
+    activeIndex = 0;
+    resetMembers();
+  }
+
+  function resetMembers() {
+    tabs.forEach((tab) => {
+      tab.classList.toggle('active', tab.dataset.category === activeCategory);
+    });
+
+    memberCards.forEach((card) => {
+      card.classList.remove('active', 'previous', 'next');
+      card.style.opacity = '0';
+      card.style.transform = 'translateX(200%)';
+    });
+
+    const members = document.querySelectorAll(`.member-card[data-category="${activeCategory}"]`);
+    activeIndex = 0;
+    prevIndex = (activeIndex - 1 + members.length) % members.length;
+    nextIndex = (activeIndex + 1) % members.length;
+
+    if (members.length > 0) {
+      members[activeIndex].classList.add('active');
+      members[prevIndex].classList.add('previous');
+      members[nextIndex].classList.add('next');
+    }
+  }
+
+  function navigate(direction) {
+    const members = document.querySelectorAll(`.member-card[data-category="${activeCategory}"]`);
+    if (members.length === 0) return;
+
+    if (prevIndex !== null) members[prevIndex].classList.remove('previous');
+    members[activeIndex].classList.remove('active');
+    if (nextIndex !== null) members[nextIndex].classList.remove('next');
+
+    if (direction === 'next') {
+      const nextnextIndex = (nextIndex + 1) % members.length;
+      prevIndex = activeIndex;
+      activeIndex = nextIndex;
+      nextIndex = nextnextIndex;
+    } else {
+      const prevprevIndex = (prevIndex - 1 + members.length) % members.length;
+      nextIndex = activeIndex;
+      activeIndex = prevIndex;
+      prevIndex = prevprevIndex;
+    }
+
+    members[activeIndex].classList.add('active');
+    if (prevIndex !== null) members[prevIndex].classList.add('previous');
+    if (nextIndex !== null) members[nextIndex].classList.add('next');
+  }
+
+  tabs.forEach((tab) => {
+    tab.addEventListener('click', () => switchCategory(tab.dataset.category));
+  });
+
+  leftArrow.addEventListener('click', () => navigate('prev'));
+  rightArrow.addEventListener('click', () => navigate('next'));
+  switchCategory('members');
+}

--- a/src/scripts/form.js
+++ b/src/scripts/form.js
@@ -1,0 +1,60 @@
+export function initTapInForm() {
+  const tapInButton = document.getElementById('tapInButton');
+  const tapInForm = document.getElementById('tapInForm');
+  const applicationForm = document.getElementById('applicationForm');
+  const confirmationMessage = document.getElementById('confirmationMessage');
+  if (!tapInButton || !tapInForm || !applicationForm || !confirmationMessage) return;
+
+  tapInButton.addEventListener('click', () => {
+    tapInForm.style.display = 'block';
+    setTimeout(() => tapInForm.classList.add('active'), 10);
+    tapInButton.style.display = 'none';
+    confirmationMessage.style.display = 'none';
+    confirmationMessage.style.opacity = '0';
+  });
+
+  applicationForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const emailField = document.getElementById('email');
+    const messageField = document.getElementById('message');
+    if (!emailField.value || !messageField.value) {
+      alert('Please fill out all required fields.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('email', emailField.value);
+    formData.append('message', messageField.value);
+
+    fetch('https://formspree.io/f/xldgoaaj', {
+      method: 'POST',
+      body: formData,
+      headers: { Accept: 'application/json' }
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.ok) {
+          tapInForm.style.display = 'none';
+          confirmationMessage.style.display = 'flex';
+          setTimeout(() => {
+            confirmationMessage.style.opacity = '1';
+          }, 10);
+
+          setTimeout(() => {
+            confirmationMessage.style.opacity = '0';
+            setTimeout(() => {
+              confirmationMessage.style.display = 'none';
+              confirmationMessage.style.height = '0';
+              tapInButton.style.display = 'block';
+            }, 400);
+          }, 2500);
+        } else {
+          alert('Submission failed. Please try again.');
+        }
+      })
+      .catch(() => {
+        alert('Something went wrong. Try again.');
+      });
+  });
+}

--- a/src/scripts/hero.js
+++ b/src/scripts/hero.js
@@ -1,0 +1,46 @@
+export function initDynamicWords() {
+  const words = document.querySelectorAll('.dynamic-words span');
+  if (!words.length) return;
+
+  let currentIndex = 0;
+  let interval = 850;
+
+  function cycleWords() {
+    words[currentIndex].classList.remove('active');
+    words[currentIndex].classList.add('inactive');
+
+    currentIndex = (currentIndex + 1) % words.length;
+    words[currentIndex].classList.remove('inactive');
+    words[currentIndex].classList.add('active');
+
+    if (currentIndex === words.length - 1) return;
+
+    if (interval === 1000) interval = 800;
+    else if (interval > 300) interval -= 150;
+
+    setTimeout(cycleWords, interval);
+  }
+
+  words[currentIndex].classList.add('active');
+  setTimeout(cycleWords, interval);
+}
+
+export function initParallax() {
+  document.addEventListener('scroll', () => {
+    const scrollY = window.scrollY;
+    const logo = document.querySelector('.parallax-image');
+    const leftImage = document.querySelector('.parallax-left');
+    const rightImage = document.querySelector('.parallax-right');
+    if (!logo) return;
+
+    if (window.innerWidth < 768) {
+      logo.style.transform = `translateY(${scrollY * 0.1}px) translateZ(0)`;
+      if (leftImage) leftImage.style.transform = `translateY(${scrollY * 0.02}px) translateZ(0)`;
+      if (rightImage) rightImage.style.transform = `translateY(${scrollY * 0.02}px) translateZ(0)`;
+    } else {
+      logo.style.transform = `translateY(${scrollY * 0.2}px) translateZ(0)`;
+      if (leftImage) leftImage.style.transform = `translateY(${scrollY * 0.03}px) translateZ(0)`;
+      if (rightImage) rightImage.style.transform = `translateY(${scrollY * 0.05}px) translateZ(0)`;
+    }
+  });
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,0 +1,16 @@
+import { initTeamCarousel } from './carousel.js';
+import { initTapInForm } from './form.js';
+import { initDynamicWords, initParallax } from './hero.js';
+import { initNavHighlight } from './nav.js';
+import { initScrollAnimations } from './scroll.js';
+
+initNavHighlight();
+
+document.addEventListener('DOMContentLoaded', () => {
+  initDynamicWords();
+  initTeamCarousel();
+  initTapInForm();
+});
+
+initParallax();
+initScrollAnimations();

--- a/src/scripts/nav.js
+++ b/src/scripts/nav.js
@@ -1,0 +1,8 @@
+export function initNavHighlight() {
+  document.querySelectorAll('.main-nav a').forEach((link) => {
+    link.addEventListener('click', (event) => {
+      document.querySelectorAll('.main-nav a').forEach((navLink) => navLink.classList.remove('active'));
+      event.currentTarget.classList.add('active');
+    });
+  });
+}

--- a/src/scripts/scroll.js
+++ b/src/scripts/scroll.js
@@ -1,0 +1,28 @@
+function divActive() {
+  const divs = document.querySelectorAll('.slide-in');
+  divs.forEach((div) => {
+    const slideInAt = window.scrollY + window.innerHeight - div.offsetHeight / 2;
+    if (slideInAt > div.offsetTop) div.classList.add('active');
+    else div.classList.remove('active');
+  });
+}
+
+function debounce(func, wait = 10, immediate = true) {
+  let timeout;
+  return function wrapped() {
+    const context = this;
+    const args = arguments;
+    const later = function laterFn() {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+    const callNow = immediate && !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (callNow) func.apply(context, args);
+  };
+}
+
+export function initScrollAnimations() {
+  window.addEventListener('scroll', debounce(divActive));
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,1204 @@
+/* ===============================
+   BASE & VARIABLES
+   =============================== */
+:root {
+  --gold: #C9A255;
+  --purple: #7A3FB6;
+  --black: #000;
+  --white: #fff;
+  --gray-dark: #1a1a1a;
+}
+
+/* Reset & Global Defaults */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* 
+     Base font: 100% typically equals the browser default of ~16px.
+     By using % for font-size, everything else can scale accordingly.
+  */
+body {
+  font-size: 100%;
+  font-weight: 600;
+  /* Slightly bolder for all text*/
+  font-family: "Poppins", sans-serif;
+  background-color: var(--black);
+  color: var(--white);
+  line-height: 1.6;
+  /* Keep line-height unitless or numeric for flexibility */
+}
+
+/* ===============================
+     HEADER
+     =============================== */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  background-color: var(--gray-dark);
+  padding: 1% 2%;
+  margin-right: -1%;
+  justify-content: space-between;
+}
+
+/* Logo sizing */
+.logo-img {
+  width: 6%;
+  min-width: 80px;
+  object-fit: contain;
+  margin-right: 2rem;
+}
+
+/* Push nav to the right */
+.main-nav {
+  margin-left: 0;   
+  flex: 1;   
+}
+
+/* Horizontal list of links */
+.main-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin:0;
+  padding: 0;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+}
+
+/* Nav links themselves */
+.main-nav a {
+  text-decoration: none;
+  color: var(--white);
+  font-size: 170%;
+  font-weight: 600;
+  padding: 0.5% 1%;
+  display: inline-block;
+  transition: color 0.2s;
+}
+
+.main-nav a:hover {
+  color: var(--gold);
+}
+
+.main-nav a.active {
+  color: var(--gold);
+}
+
+
+/* The following prevents a couple extra pixels so that there isn't any side scroll */
+html, body {
+  max-width: 100%;
+  overflow-x: hidden;   /* hard stop for any stray overflow */
+}
+img, video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ===============================
+     HERO SECTION
+     =============================== */
+.hero {
+  position: relative;
+  min-height: 50vh; /* Ensure height stays proportional */
+  display: flex; /* Use flexbox to align items */
+  flex-direction: column; /* Stack elements vertically */
+  align-items: center; /* Center horizontally */
+  justify-content: flex-start; /* Align to the top */
+  background: linear-gradient(45deg, var(--purple), var(--gold));
+  background-size: cover;
+  background-blend-mode: overlay;
+  overflow: hidden; /* Prevent content overflow */
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: url('/Textures/1.png') repeat; /* Add texture */
+  opacity: 0.1; /* Reduce opacity for subtle effect */
+  z-index: 0; /* Ensure this is behind everything */
+}
+
+.hero-overlay {
+  text-align: center;
+  margin-top: -1rem; /* Reduce spacing above text */
+}
+
+.hero-overlay p {
+  font-size: 2rem;
+  line-height: 1.5;
+  color: var(--white); 
+  text-shadow: 4px 4px 8px rgba(0, 0, 0, 0.721);
+}
+
+/* begining of logo and images in hero*/
+.parallax-image {
+  width: 30%; /* Proportional size */
+  margin-top: -6rem; /* Remove margins */
+  margin-bottom: 2rem;
+  z-index: 5; /* Ensure above background */
+  position: relative;
+}
+
+.hero-images {
+  display: flex;
+  justify-content: space-between; /* Distribute images to sides */
+  width: 100%; /* Full width of the Hero section */
+  max-width: 1200px; /* Optional: Limit width for better alignment */
+  margin-top: -8rem; /* Reduce spacing above */
+  margin-bottom: -7rem; /* Reduce spacing below */
+  z-index: 4; /* Ensure they’re above the background */
+}
+
+.parallax-left {
+  width: 15%; /* Adjust size proportionally */
+  transform: translateY(0); /* Parallax effect will apply here */
+  margin-left: -10%;
+}
+
+.parallax-right {
+  width: 15%; /* Adjust size proportionally */
+  transform: translateY(0); /* Parallax effect will apply here */
+  margin-right: -10%;
+}
+/* End of logo and image area */
+
+/* Specific Elements */
+/*.intro-text {
+  font-size: 2.5rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: var(--white); 
+  margin-left: -18%;
+}*/
+
+/* beginning of initial word sliding effect */
+.key-roles {
+  font-family: 'Poppins', sans-serif;
+  font-size: 3.5rem;
+  font-weight: 700;
+  text-align: center;
+  color: var(--gold);
+  position: relative;
+  padding: 1rem 0; /* Add vertical padding */
+  height: calc(5.5rem + 1rem); /* Account for the added padding */  
+  line-height: 6rem; 
+  overflow: hidden; /* Ensures no words overflow */
+}
+
+.dynamic-words {
+  position: relative;
+  height: 3.5rem; /* Match the font size */
+  display: block;
+}
+
+.dynamic-words span {
+  display: block;
+  position: absolute;
+  top: 0; /* Start position */
+  left: 0;
+  width: 100%;
+  font-size: 3.5rem; /* Set explicit size */
+  transform: translateY(100%); /* Start below the container */
+  opacity: 0;
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+}
+
+.dynamic-words span.active {
+  transform: translateY(0); /* Bring into view */
+  opacity: 1;
+}
+
+.dynamic-words span.inactive {
+  transform: translateY(-100%); /* Slide out above the container */
+  opacity: 0;
+}
+
+.dynamic-words span.active:last-of-type {
+  animation: scale-up 1s ease forwards;
+  text-shadow: 
+    0 0 5px #f6b534,    /*Inner glow */
+    0 0 9px #f8c96a;   /* Maximum spread glow */
+  font-weight: bold;
+  color: rgb(255, 255, 255); /* Adds a subtle hover color shift */
+}
+
+@keyframes scale-up {
+  0% { transform: scale(1); }
+  100% { transform: scale(2); }
+}
+
+/*end of initial word sliding effect */
+
+/* beginning of final hero statement sentence */
+.hero-statement {
+  font-size: 2rem;
+  line-height: 1.5;
+  margin-top: 1rem;
+}
+
+.hero-statement .emphasis {
+  text-decoration: underline;
+  font-weight: bold;
+  text-shadow: 
+    4px 4px 8px #00000049,
+    4px 4px 8px #8343c3e1;
+  font-size: 2.3rem;
+}
+
+.tagline {
+  font-size: 2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.tagline .glow {
+  font-weight: bold;
+  color: var(--purple);
+  text-shadow: 0 0 10px var(--gold), 0 0 20px var(--gold);
+  animation: glow-effect 1.5s infinite alternate;
+}
+
+/* Glowing Animation */
+@keyframes glow-effect {
+  from {
+    text-shadow: 0 0 10px var(--gold), 0 0 20px var(--gold);
+  }
+  to {
+    text-shadow: 0 0 15px var(--gold), 0 0 25px var(--gold);
+  }
+}
+/* ===============================
+     END OF HERO SECTION
+     =============================== */
+
+/* ===============================
+     WHY? SECTION
+     =============================== */
+
+.why-section {
+  background-color: var(--black);
+  color: var(--white);
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+.why-text {
+  font-size: 1.6rem;
+  max-width: 800px;
+  margin: 0 auto;
+  line-height: 1.6;
+  color: var(--white);
+}
+
+/* ===============================
+     END OF WHY? SECTION
+     =============================== */
+
+/* ===============================
+     MISSION SECTION
+     =============================== */
+.mission-statement {
+  background-color: var(--black);
+  color: var(--white);
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.section-title {
+  font-size: 2.5rem;
+  color: var(--gold);
+  margin-bottom: 3rem;
+  text-transform: uppercase;
+}
+
+.social-title {
+  font-size: 2.8rem;
+  color: var(--gold);
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+  text-shadow: 0px 0px 8px var(--gold);
+}
+
+/* Mission Cards */
+.mission-cards {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.mission-card {
+  position: relative;
+  color: var(--white);
+  border-radius: 8px;
+  width: 25%;
+  height: 300px; /* Set height for a proportional look */
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+  overflow: hidden;
+  transition: all 0.3s ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mission-card:nth-child(1) {
+  background: url('/Mission/LeftMission.png'); 
+  background-size: cover;
+}
+
+.mission-card:nth-child(2) {
+  background: url('/Mission/CenterMission.png'); 
+  background-size: cover;
+}
+
+.mission-card:nth-child(3) {
+  background: url('/Mission/RightMission.png'); 
+  background-size: cover;
+}
+
+.mission-card:hover {
+  background-color: var(--gold); /* Solid color on hover */
+  transform: scale(1.05); /* Subtle scaling */
+}
+
+.mission-card::before {
+  content: attr(data-title);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.8rem;
+  color: var(--white);
+  text-transform: uppercase;
+  text-shadow: 1px 1px 5px rgba(0, 0, 0, 0.5);
+  opacity: 1;
+  transition: opacity 0.3s ease-in-out;
+
+  /* Border and Padding for Sub-Titles */
+  border: 2px solid var(--white); /* Adds a gold border */
+  padding: 0.5rem 1rem; /* Adds breathing room around the text */
+  border-radius: 8px; /* Rounds the border edges */
+  background-color: rgba(0, 0, 0, 0.6); /* Subtle background for contrast */
+}
+
+.mission-card:hover::before {
+  opacity: 0; /* Fade out the title on hover */
+}
+
+.mission-text {
+  opacity: 0;
+  visibility: hidden;
+  font-size: 1.5rem;
+  color: var(--black);
+  line-height: 1.5;
+  text-align:inherit; /* Center-align text */
+  width: 100%; /* Ensure the text spans most of the card width */
+  max-width: 100%; /* Prevent overflow */
+  padding: 0 0rem; /* Add padding for better readability */
+  box-sizing: border-box; /* Include padding in width calculations */
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+}
+
+.mission-card:hover .mission-text {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* Hover Animation */
+.mission-card:hover {
+  background: var(--gold); /* Change to a solid color for contrast */
+}
+
+/* ===============================
+     END OF MISSION SECTION
+     =============================== */
+
+/* ===============================
+     START OF MEMBERS/ARTIST SECTION
+     =============================== */
+
+/* Section Base Styles */
+.members-section {
+  background-color: var(--black);
+  color: var(--white);
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+.Members-title {
+  font-size: 2.8rem;
+  color: var(--gold);
+  text-transform: uppercase;
+  margin-top: -7rem;
+  margin-bottom: 2rem;
+  text-shadow: 0px 0px 8px var(--gold);
+}
+
+/* Section Title */
+.section-title {
+  font-size: 2.8rem;
+  color: var(--gold);
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+  text-shadow: 0px 0px 8px var(--gold);
+}
+
+/* Category Tabs */
+.category-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 2rem; /* Increased spacing */
+  margin-bottom: 2.5rem;
+  max-width: 80%; /* Match section width */
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tab {
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  cursor: pointer;
+  padding: 0.8rem 2rem;
+  border-bottom: 3px solid transparent;
+  transition: all 0.3s ease-in-out;
+  color: #b7b7b7;
+  opacity: 0.65;
+}
+
+.tab.active {
+  color: var(--gold);
+  border-bottom: 3px solid var(--gold);
+  font-size: 1.8rem;
+  text-shadow: 0px 0px 10px var(--gold);
+  opacity: 1;
+}
+
+/* Arrows */
+.arrow {
+  font-size: 3rem; 
+  color: var(--gold);
+  background: none;  
+  border: 0.25rem solid var(--gold); 
+  border-radius: 50%; /* Keep rounded shape */
+  width: 60px; 
+  height: 60px; 
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease-in-out, border-color 0.3s ease;
+  z-index: 100 !important;
+}
+
+.arrow:hover {
+  transform: scale(1.05);
+  border-color: var(--white); 
+}
+
+.left-arrow {
+  left: 4rem;
+}
+
+.right-arrow {
+  right: 4rem;
+}
+
+
+/* Carousel */
+.carousel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  max-width: 900px; /* Slightly larger */
+  margin: 0 auto;
+}
+
+/* Member Cards */
+.carousel-inner {
+  display: flex;
+  flex-direction: column;    
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+  position: relative; /* Ensures absolute positioning inside */
+  height: 30rem; 
+}
+
+.member-card {
+  display: flex;
+  flex-direction: column;
+  position: absolute !important;         
+  align-items: center;
+  background: linear-gradient(135deg, var(--purple), var(--gold));
+  border-radius: 15px;
+  width: 30rem;         
+  height: 30rem;
+  padding: 1rem;
+  transform: translate(-50%, -50%) translateX(200%);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+  transition: transform 0.4s ease-in-out, opacity 0.4s ease-out;
+}
+
+.member-name {
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  background-color: var(--gold);
+  color: var(--black);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+  width: 100%;
+  text-align: center;
+}
+
+.member-card.active {
+  opacity: 1 !important;
+  transform: translateX(0) !important;
+}
+
+.member-card.previous {
+  transform: translateX(-100%) !important;
+  opacity: 0;
+}
+
+.member-card.next {
+  transform: translateX(100%) !important;
+  opacity: 0;
+}
+
+/* Image Hover Effect */
+.member-image {
+  width: 20rem;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+}
+
+.member-card:hover {
+  transform: scale(1.05);
+}
+
+/* Member Details */
+.member-details {
+  flex: 1;
+  text-align: center;
+}
+
+.member-card.active .member-details {
+  display: block;
+}
+
+.member-bio {
+  font-size: 0.9rem;
+  line-height: 1.3;
+  margin-bottom: 0.75rem;
+}
+
+/* Social Links */
+.social-links {
+  display: flex;
+  gap: 10px; /* Space between icons */
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.social-links a {
+  display: inline-block;
+  width: 40px; /* Adjust size */
+  height: 40px;
+  transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
+}
+
+.social-links a img {
+  width: 100%; /* Makes sure the images fill the anchor */
+  height: auto;
+  filter: brightness(1); /* Normal brightness */
+  transition: filter 0.3s ease-in-out;
+}
+
+/* Hover Effects */
+.social-links a:hover {
+  transform: scale(1.2); /* Slight pop effect */
+}
+
+.social-links a:hover img {
+  filter: brightness(1.3); /* Slight glow effect */
+}
+
+.social-links a.Youtube img {
+  margin-top: 5px; /* Adjust as needed */
+}
+
+/* ===============================
+     END OF MEMBERS/ARTIST SECTION
+     =============================== */
+
+/* ===============================
+     CONTACT SECTION
+     =============================== */
+/* TAP IN SECTION */
+/* Tap In Section */
+.tap-in-section {
+  text-align: center;
+  padding: 1rem 2rem; /* Reduced padding */
+  position: relative;
+  margin-bottom: 0; /* Remove extra spacing */
+  margin-top: -3rem;
+}
+
+/* Tap In Button */
+.tap-in-btn {
+  font-size: 3.2rem;
+  padding: 2.5rem 5.5rem;
+  background-color: var(--gold);
+  color: var(--white);
+  font-weight: bold;
+  border: none;
+  border-radius: 50px;
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: all 0.3s ease-in-out;
+  box-shadow: 0px 0px 25px var(--gold);
+  animation: glowEffect 1.5s infinite alternate ease-in-out;
+  visibility: visible; /* Ensures it stays in place */
+  position: relative;
+}
+
+/* Expanded Form */
+.tap-in-form {
+  display: none;
+  width: 60%;
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 3rem;
+  border-radius: 20px;
+  background: url('/Apply/ApplicationBoxPattern3.png') center/cover no-repeat;
+  position: relative;
+  transition: all 0.3s ease-in-out;
+}
+
+.tap-in-form.active {
+  display: block;
+  opacity: 1;
+  transform: scale(1);
+}
+
+/* Submission Confirmation */
+.confirmation-message {
+  display: none;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  background-color: var(--gold);
+  color: var(--white);
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin-top: 1rem;
+  margin-bottom: 3rem;
+  border-radius: 20px;
+  padding-top: 2rem;
+  padding-bottom: -2rem;
+  width: 50%;
+  max-width: 600px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out, transform 0.4s ease-in-out;
+}
+
+/* Dark Overlay for Readability */
+.tap-in-form::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); /* Subtle dark overlay */
+  border-radius: 20px;
+  z-index: 1;
+}
+
+/* Ensure form content appears above the overlay */
+.tap-in-form * {
+  position: relative;
+  z-index: 2;
+}
+
+/* FORM INPUTS (Increased size for better usability) */
+.tap-in-form label {
+  font-size: 1.6rem; /* Slightly larger labels */
+  font-weight: bold;
+  color: var(--white);
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.tap-in-form input,
+.tap-in-form textarea {
+  font-size: 1.4rem; /* Bigger text fields */
+  padding: 1rem;
+  width: 100%;
+  border-radius: 10px;
+  border: none;
+}
+
+/* APPLY BUTTON */
+.apply-btn {
+  font-size: 2.2rem; /* Bigger text */
+  padding: 1.2rem 3.5rem; /* Larger button */
+  margin-top: 1rem;
+  color: var(--white);
+  background-color: var(--gold);
+  font-weight: bold;
+  border-radius: 20px; /* More rounded edges */
+}
+
+/* ===============================
+     END OF CONTACT SECTION
+     =============================== */
+
+/* ===============================
+  SOCIALS SECTION
+=============================== */
+
+.socials-section {
+  background-color: var(--black);
+  text-align: center;
+  padding: 1rem 4rem;
+  margin-top: 0%;
+}
+    
+/* The social media buttons here use the css from the MEMBERS/ARTIST Section. 
+    
+/* ===============================
+  END OF SOCIALS SECTION
+=============================== */
+
+/* ===============================
+     FOOTER
+     =============================== */
+.site-footer {
+  background-color: var(--gray-dark);
+  text-align: center;
+  padding: 3%;
+  color: var(--white);
+  font-size: 90%;
+}
+
+/* ===============================
+     RESPONSIVE BREAKPOINT
+     =============================== */
+@media (max-width: 768px) {
+
+  .hero,
+  .mission-statement,
+  .members-section,
+  .socials-section,
+  .site-footer {
+    width: 100%;
+    padding-left: 1rem;
+    padding-right: 1rem;
+    box-sizing: border-box;
+  }
+
+  .logo-img {
+    flex-shrink: 0;                 
+    width: auto;
+    height: 50px;                   
+    min-width: 0;                   
+    margin-right: 1rem;           
+  }
+
+  body {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .parallax-image {
+    width: 80%;
+    margin-top: -2rem;
+    margin-bottom: 1rem;
+  }
+
+  /* Possibly reduce hero size on smaller screens */
+  .hero {
+    flex-direction: column;
+    padding: -1rem 0rem;
+  }
+
+  /* Stack the header contents vertically */
+  .site-header {
+    display: flex;
+    flex-direction: row;            /* lay items out in a row */
+    align-items: center;            /* vertically center logo + links */
+    justify-content: flex-start;    /* logo on the left, nav after */
+    padding: 0.5rem 1rem;
+  }
+
+  .site-header .logo-img {
+    /* let it scale naturally, but keep it small enough for tabs */
+    width: auto;
+    height: 70px;      /* pick a comfortable height for phones */
+    min-width: 0;      /* override the desktop min-width */
+    max-width: 200px;  /* optional cap */
+    margin-bottom: 0;  /* keep it aligned with the nav */
+  }
+
+  /* Make nav take available space and center the links */
+  .main-nav {
+    width: 100%;
+    text-align: center;
+    margin: 0.5rem 0;
+  }
+
+  .key-roles {
+    font-size: 2.5rem;   /* reduce font size on mobile */
+    line-height: 1.5;
+    overflow: hidden;
+    padding: 1rem 0;
+  }
+
+  .key-roles .dynamic-words span {
+    font-size: inherit;  /* inherit smaller font-size */
+  }
+
+  .dynamic-words span.active:last-of-type {
+    animation: scale-up 1s ease forwards;
+    font-size: 1.35rem;  /* inherit smaller font-size */
+    text-shadow: 
+      0 0 5px #f6b534,    /*Inner glow */
+      0 0 9px #f8c96a;   /* Maximum spread glow */
+    font-weight: bold;
+    color: rgb(255, 255, 255); /* Adds a subtle hover color shift */
+  }
+  
+  /* Keep nav links horizontal and shrink gap/padding */
+  .main-nav{
+    display: none;
+  }
+
+
+  /* In narrower viewports, let .hero-overlay be almost full-width */
+  .hero-overlay {
+    width: 95%;
+    padding: 4% 2%;
+    text-align: center;
+    overflow: hidden;  /* prevents text from overflowing */
+  }
+
+  .intro-text {
+    margin-left: 0;
+    margin-top: -1.25rem;
+    font-size: 2rem; /* Adjust font-size for mobile */
+  }
+
+  .hero-overlay .hero-statement {
+    font-size: 1.7rem;
+    margin-top: -2rem;
+  }
+
+  .tagline {
+    margin-top: 1rem;
+  }
+
+  .hero-statement .emphasis {
+    text-decoration: underline;
+    display: block; 
+    font-weight: bold;
+    text-shadow: 
+      4px 4px 8px #00000049,
+      4px 4px 8px #8343c3e1;
+    font-size: 2rem;
+  }
+
+  /* Stack .vision-content vertically */
+  .vision-content {
+    flex-direction: column;
+  }
+
+  /* Stack .highlights items vertically */
+  .highlights {
+    flex-direction: column;
+  }
+
+  .category-tabs {
+    display: flex;
+    flex-wrap: wrap;           /* allow multiple rows if needed */
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .carousel {
+    position: relative;
+    max-width: 100%;
+    margin: 0 auto;
+    overflow: hidden; /* Ensure extra cards don’t spill out */
+  }
+
+  .tab {
+    font-size: 1.2rem;
+    padding: 0.5rem 1rem;
+    white-space: nowrap;       /* prevent overlong labels from breaking awkwardly */
+  }
+
+  .section-title {
+    font-size: 2.8rem;
+    color: var(--gold);
+    text-transform: uppercase;
+    margin-top: -3rem;
+    margin-bottom: 2rem;
+    text-shadow: 0px 0px 8px var(--gold);
+  }
+
+  .Members-title {
+    font-size: 2.8rem;
+    color: var(--gold);
+    text-transform: uppercase;
+    margin-top: -8rem;
+    margin-bottom: 2rem;
+    text-shadow: 0px 0px 8px var(--gold);
+  }
+
+  .social-title {
+    font-size: 2.8rem;
+    color: var(--gold);
+    text-transform: uppercase;
+    margin-bottom: 2rem;
+    text-shadow: 0px 0px 8px var(--gold);
+  }
+
+  /* Stack team members in a column */
+  .team-grid {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .team-member {
+    flex: 0 1 80%;
+  }
+  .mission-cards {
+    flex-direction: column;
+    align-items: center;
+  }
+  
+  .mission-card {
+    width: 90%;
+    margin-bottom: 2rem;
+    height: auto; /* Allow height to adjust based on content */
+    padding: 1.5rem;
+  }
+
+  .carousel-inner {
+    position: relative;
+    width:100%;
+    height: 400px;  /* Adjust height if needed */
+    overflow: hidden;
+  }
+
+  .member-card {   
+    position: absolute;
+    top: 0;
+    background-position: center;
+    width: 90%;     
+    height: 95%;
+    transition: transform 0.8s ease, opacity 0.8s ease;
+  }
+
+  .member-image {
+    width: 15rem;
+    object-fit: cover;
+    border-radius: 8px;
+    margin-bottom: 0.75rem;
+  }
+  
+  .member-card:hover {
+    transform: scale(1.05);
+  }
+
+  .member-card.active {
+    transform: translateX(0);
+    opacity: 1;
+    z-index: 2;
+  }
+
+  .member-card.previous {
+    transform: translateX(-100%);
+    opacity: 0;
+    z-index: 1;
+  }
+
+  .member-card.next {
+    transform: translateX(100%);
+    opacity: 0;
+    z-index: 1;
+  }
+
+  /* Hide carousel navigation arrows if they clutter small screens */
+  .arrow {
+    display: block;
+    position: absolute;
+    top: 50%;
+    color: var(--gold);
+    background: none;  
+    border: 0rem solid var(--gold); 
+    border-radius: 5%; /* Keep rounded shape */
+    width: 40px; 
+    height: 40px; 
+    transform: translateY(-50%) !important;  /* Centers arrow vertically */
+    font-size: 3rem;
+    padding: 0.3rem;
+    cursor: pointer;
+    z-index: 100 !important;
+  }
+
+  .arrow:hover {
+    transform: translateY(-50%) scale(1.05) !important;
+  }
+
+  .left-arrow {
+    left: 0.5rem;
+  }
+  
+  .right-arrow {
+    right: 0.5rem;
+  }
+
+  .arrow:active {
+    transform: translateY(-50%) !important;
+  }
+
+  .socials-section{
+    margin-top: -2rem;
+    margin-bottom: 1rem;
+  }
+
+  .social-icons {
+    margin-top: -1rem;
+  }
+
+  .tap-in-section {
+    text-align: center;
+    padding: 2rem 2rem; /* Reduced padding */
+    position: relative;
+    margin-bottom: 0; /* Remove extra spacing */
+    margin-top: -5rem;
+  }
+
+  /* Tap In Button */
+  .tap-in-btn {
+    text-align: center;
+    font-size: 3rem;  
+    padding: 2.5rem 1rem;
+    background-color: var(--gold);
+    color: var(--white);
+    font-weight: bold;
+    width: 80%;
+    border: none;
+    border-radius: 50px;
+    cursor: pointer;
+    text-transform: uppercase;
+    transition: all 0.3s ease-in-out;
+    box-shadow: 0px 0px 25px var(--gold);
+    animation: glowEffect 1.5s infinite alternate ease-in-out;
+    visibility: visible; /* Ensures it stays in place */
+    position: relative;
+  }
+
+  .apply-btn {
+    transform: translateX(-9%) !important;
+    font-size: 2.2rem; /* Bigger text */
+    padding: 1.2rem 1.6rem; /* Larger button */
+    margin-top: 1rem;
+    color: var(--white);
+    background-color: var(--gold);
+    font-weight: bold;
+    border-radius: 20px; /* More rounded edges */
+  }
+
+  /* Expanded Form */
+  .tap-in-form {
+    width: 80%;
+    padding: 2rem;
+  }
+
+  /* Submission Confirmation */
+  .confirmation-message {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    flex-direction: column;
+    background-color: var(--gold);
+    color: var(--white);
+    font-size: 2rem;
+    font-weight: bold;
+    text-align: center;
+    margin-top: 1rem;
+    margin-bottom: 3rem;
+    border-radius: 20px;
+    padding-top: 2rem;
+    padding-bottom: -2rem;
+    width: 50%;
+    max-width: 600px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    transition: opacity 0.4s ease-in-out, transform 0.4s ease-in-out;
+  }
+
+  /* FORM INPUTS (Increased size for better usability) */
+  .tap-in-form label {
+    font-size: 0.9rem; 
+    font-weight: bold;
+    color: var(--white);
+    display: block;
+    margin-bottom: 0.5rem;
+  }
+
+  .tap-in-form input,
+  .tap-in-form textarea {
+    font-size: 0.9rem; /* Bigger text fields */
+    padding: 0 rem;
+    width: 100%;
+    border-radius: 10px;
+    border: none;
+  }
+
+}
+
+/* ===============================
+     OBSERVE ON SCROLL
+     =============================== */
+
+.slide-in {
+  opacity: 10%;
+  transition: opacity 0.5s;
+}
+
+.slide-in.active {
+  transition: opacity 0.5s;
+  opacity: 100%;
+  visibility: visible !important;
+}


### PR DESCRIPTION
### Motivation

- Move the monolithic site into a static, component-driven Astro project to make maintenance and reuse easier.
- Externalize team/member data into a single JSON file for non-developer content updates and to drive a reusable carousel component.
- Add basic developer tooling (ESLint, Prettier) and npm scripts to support local development, formatting and linting.

### Description

- Add an Astro project configuration with `astro.config.mjs` set to `output: 'static'` and `publicDir: './images'` and create `package.json` with `dev`, `build`, `preview`, `lint`, and `format` scripts.
- Introduce a `src/` layout and page structure including `src/layouts/BaseLayout.astro` and `src/pages/index.astro` plus modular UI components in `src/components/` (`Header.astro`, `Hero.astro`, `Mission.astro`, `TeamCarousel.astro`, `JoinForm.astro`, `Socials.astro`, `Footer.astro`).
- Externalize team data to `src/content/team.json` and implement client interaction modules in `src/scripts/` (`main.js`, `carousel.js`, `form.js`, `hero.js`, `nav.js`, `scroll.js`) to replicate legacy behaviors (carousel, tap-in form, parallax, dynamic words, scroll animations, nav highlight).
- Add global styles in `src/styles/global.css`, ESLint config `eslint.config.mjs`, Prettier config `.prettierrc` (with `prettier-plugin-astro`), and a README describing the refactor and run/deploy instructions.

### Testing

- No automated tests were executed as part of this change.
- Developer helper scripts were added so checks can be run locally via `npm run dev`, `npm run build`, `npm run preview`, `npm run lint`, and `npm run format`.
- Manual verification is expected by running `npm install` then `npm run dev` or `npm run build` to validate the static site output locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f35dd37648323b5f8f54b406f52c7)